### PR TITLE
Added support for reporting device info via dweet.io

### DIFF
--- a/config.h
+++ b/config.h
@@ -1,15 +1,16 @@
 // conditional compile flags
 
-#define DEBUG     // Output to serial port
+//#define DEBUG     // Output to serial port
 #define SCREEN      // output to screen
 //#define MQTTLOG     // Output to MQTT broker
 //#define RJ45      // use Ethernet
-//#define WIFI        // use WiFi
-//#define NTP         // query network time server
-#define BATTERY		// use battery monitoring hardware
+#define WIFI        // use WiFi
+#define NTP         // query network time server
+//#define BATTERY		// use battery monitoring hardware
 #define CO2_SENSOR	// CO2, temp, humidity sensor instead of temp, humidity sensor
 #define ONE_TIME	// run every x minutes and sleep
-//#define WEATHER  	// query weather sensor for outside conditions
+#define WEATHER  	// query weather sensor for outside conditions
+#define DWEET     // Post sensor readings to dweet.io
 
 // logging interval in minutes
 #ifdef DEBUG
@@ -70,6 +71,14 @@
     #define BATTERYSIZE LC709203F_APA_1000MAH // 0x19
 	  // #define BATTERYSIZE LC709203F_APA_2000MAH // 0x2D
     // #define BATTERYSIZE LC709203F_APA_3000MAH // 0x36
+#endif
+
+// Post data to the internet via dweet.io.  Set DWEET_DEVICE to be a
+// unique name you want associated with this reporting device, allowing
+// data to be easily retrieved through the web or Dweet's REST API.
+#ifdef DWEET
+  #define DWEET_HOST "dweet.io"   // Typically dweet.io
+  #define DWEET_DEVICE "makerhour-airquality"  // Must be unique across all of dweet.io
 #endif
 
 // the following parameters are defined in secrets.h


### PR DESCRIPTION
Added optional support for posting info via dweet.io, as follows:
*) added a configuration #define DWEET in config.h to enable/disable dweeting
*) added a utility function, post_dweet(), to compose a JSON payload using sensor values passed in as arguments, and then submit the HTTP POST
*) added necessary #defines to config.h to set the target dweet host (dweet.io) and a default device name (makerhour-airquality), but allow them to be easily customized
*) modified actionSequence() to call post_dweet() if #DWEET is defined
*) made sure to use debugMessage() for all Serial output so #DEBUG is properly respected

Devices post via dweet their sensor readings as well as IP address and RSSI of most recent WiFi communications (the later two are helpful in debugging)

Users can see the device's dweeted info at https://dweet.io/get/latest/dweet/for/makerhour-airquality (or replace makerhour-airquality with the name specified by #DWEET_DEVICE). Dweet.io is free, does not require an account, and does not use API keys for access (or data retrieval), thanks to the benevolent wizardry of folks at BugLabs.

I tested with my device over the course of a day to confirm proper operation.

While at it I moved the #include of "secrets.h" up to the top of the main sketch immediately after the #include of "config.h" to make sure that anything defined in secrets.h had maximum opportunity to be included in additional #defines or conditional compilation in the main sketch, and added debugMessage() calls to echo out key configuration values if operating in #DEBUG mode.

All changes are in branch 'dweet'.