### PR TITLE
Post refactor adjustments, plus added support for Dweet.io

### DIFF
--- a/air_quality.ino
+++ b/air_quality.ino
@@ -177,8 +177,8 @@ void setup()
   if (lc.begin())
   {
     debugMessage("Battery voltage monitor ready");
-    // lc.setPackSize(BATTERYSIZE);
-    lc.setPackAPA(BATTERY_APA);
+    lc.setPackSize(BATTERYSIZE);   // If library version 1.1.0 or earlier
+    // lc.setPackAPA(BATTERY_APA); // Uses new library API. See comments in config.h
     batteryAvailable = true;
   }
   else

--- a/config.h
+++ b/config.h
@@ -62,16 +62,24 @@ const int timeZone = -8;  // USA PST
 #define MQTT_PUB_TOPIC3		"sircoolio/feeds/test-room.co2"
 #define MQTT_PUB_TOPIC4		"sircoolio/feeds/test-room.errmessage"
 
-// select battery size closest to used
+// Current version of Adafruit LC709203F library sets battery size (APA value) 
+// using a fixed, limited set of defined values enumerated in LC709203F.h.  
+// Select the one closest to the battery size being used
 // #define BATTERYSIZE LC709203F_APA_100MAH // 0x08
 // #define BATTERYSIZE LC709203F_APA_200MAH // 0x0B
-// #define BATTERYSIZE LC709203F_APA_500MAH	// 0x10
-// #define BATTERYSIZE LC709203F_APA_1000MAH // 0x19
+// #define BATTERYSIZE LC709203F_APA_500MAH  // 0x10
+#define BATTERYSIZE LC709203F_APA_1000MAH // 0x19
 // #define BATTERYSIZE LC709203F_APA_2000MAH // 0x2D
 // #define BATTERYSIZE LC709203F_APA_3000MAH // 0x36
 
-#define BATTERY_APA 0x1D // 1200 mAH per LC709203F datasheet
-#define BATTERY_ALERT_PCT 20  // Threshold for low battery alert (MQTT)
+// A pending update to the Adafruit LC709203F library adds a new function that
+// allows setitng battery APA value directly, based on a settings curve in the
+// LC709203F datasheet.  Once that version becomes available we'll switch, which
+// will require a differernt #define scheme.
+// #define BATTERY_APA 0x1D // 1200 mAH per LC709203F datasheet
+
+// Set threshold for low battery alert, dispatched via MQTT
+#define BATTERY_ALERT_PCT 20  // Publishes MQTT alert if battery <= 20% charge
 
 // Post data to the internet via dweet.io.  Set DWEET_DEVICE to be a
 // unique name you want associated with this reporting device, allowing

--- a/config.h
+++ b/config.h
@@ -1,8 +1,9 @@
 // conditional compile flags
-#define DEBUG     // Output to serial port
+//#define DEBUG     // Output to serial port
 //#define RJ45    // use Ethernet
 #define WIFI    // use WiFi
 #define MQTTLOG // log sensor data to MQTT broker
+#define DWEET     // Post sensor readings to dweet.io
 
 // set logging interval in minutes
 #ifdef DEBUG
@@ -65,9 +66,20 @@ const int timeZone = -8;  // USA PST
 // #define BATTERYSIZE LC709203F_APA_100MAH // 0x08
 // #define BATTERYSIZE LC709203F_APA_200MAH // 0x0B
 // #define BATTERYSIZE LC709203F_APA_500MAH	// 0x10
-#define BATTERYSIZE LC709203F_APA_1000MAH // 0x19
+// #define BATTERYSIZE LC709203F_APA_1000MAH // 0x19
 // #define BATTERYSIZE LC709203F_APA_2000MAH // 0x2D
 // #define BATTERYSIZE LC709203F_APA_3000MAH // 0x36
+
+#define BATTERY_APA 0x1D // 1200 mAH per LC709203F datasheet
+#define BATTERY_ALERT_PCT 20  // Threshold for low battery alert (MQTT)
+
+// Post data to the internet via dweet.io.  Set DWEET_DEVICE to be a
+// unique name you want associated with this reporting device, allowing
+// data to be easily retrieved through the web or Dweet's REST API.
+#ifdef DWEET
+  #define DWEET_HOST "dweet.io"   // Typically dweet.io
+  #define DWEET_DEVICE "makerhour-airquality"  // Must be unique across all of dweet.io
+#endif
 
 // the following parameters are defined in secrets.h
 // #ifdef WIFI


### PR DESCRIPTION
Made a few modifications to the newly refactored code:

*) WIFi connection handles retry logic via for(;;) loop tied to maximum number of retries
*) Moved getWeather() inside #defines for network connectivity 
*) Consolidated internet services (getWeather(), MQTT, Dweet, etc.) into one set of #define tests for network connectivity.
*) Made the low battery alert threshold a #define in config.h to make it easier to configure,
*) Planned ahead for update to Adafruit LC709203F battery monitor library so we can switch to the new battery size/APA function when it becomes available

Also, added support for posting latest sensor values and device attributes to dweet.io, making it easy to observe operating status plus most recent readings.  Dweet attributes are set in config.h so can easily be customized.