### PR TITLE
Generalized and separated all the networking code

### DIFF
--- a/aq_network.cpp
+++ b/aq_network.cpp
@@ -1,4 +1,5 @@
 #include "Arduino.h"
+#include "aq_network.h"
 
 // hardware and internet configuration parameters
 #include "config.h"
@@ -52,7 +53,7 @@ extern void debugMessage(String messageText);
 #endif
 
 // Converts system time into human readable strings. Depends on NTP service access
-String dateTimeString()
+String AQ_Network::dateTimeString()
 {
   #if defined(WIFI) || defined(RJ45)
     String dateTime;
@@ -126,7 +127,7 @@ String dateTimeString()
 // device can report accurate local time.  Returns boolean indicating whether network is
 // connected and available.  Depends on configuration #defines in config.h to determine
 // what network hardware is attached, and key network settings there as well (e.g. SSID).
-bool networkBegin()
+bool AQ_Network::networkBegin()
 {
   bool networkAvailable = false;
   
@@ -215,7 +216,7 @@ bool networkBegin()
 }
 
 
-String httpGETRequest(const char* serverName) 
+String AQ_Network::httpGETRequest(const char* serverName) 
 {
   String payload = "{}";
   
@@ -243,14 +244,14 @@ String httpGETRequest(const char* serverName)
   return payload;
 }
 
-void networkStop()
+void AQ_Network::networkStop()
 {
   #if defined(WIFI) || defined(RJ45)
     client.stop();
   #endif
 }
 
-int httpPOSTRequest(String serverurl, String contenttype, String payload)
+int AQ_Network::httpPOSTRequest(String serverurl, String contenttype, String payload)
 {
   int httpCode = -1;
   #if defined(WIFI) || defined(RJ45)
@@ -288,7 +289,7 @@ int httpPOSTRequest(String serverurl, String contenttype, String payload)
 // Utility functions that may be of use
 
 // Return local IP address as a String
-String getLocalIPString()
+String AQ_Network::getLocalIPString()
 {
   #if defined(WIFI) || defined(RJ45)
     return(client.localIP().toString());
@@ -298,7 +299,7 @@ String getLocalIPString()
 }
 
 // Return RSSI for WiFi network, simulate out-of-range value for non-WiFi
-long getWiFiRSSI()
+long AQ_Network::getWiFiRSSI()
 {
   #ifdef WIFI
     return(WiFi.RSSI());
@@ -308,7 +309,7 @@ long getWiFiRSSI()
 }
 
 // Returns true if WIFI defined in config.h, otherwise false
-bool isWireless()
+bool AQ_Network::isWireless()
 {
   #ifdef WIFI
     return(true);
@@ -318,7 +319,7 @@ bool isWireless()
 }
 
 // Returns true if RJ45 (Ethernet) defined in config.h, otherwise false
-bool isWired()
+bool AQ_Network::isWired()
 {
   #ifdef RJ45
     return(true);
@@ -328,7 +329,7 @@ bool isWired()
 }
 
 // Returns connection status (via Client class), or false if no network defined in config.h
-bool isConnected()
+bool AQ_Network::isConnected()
 {
   #if defined(WIFI) || defined(RJ45)
     return(client.connected());

--- a/aq_network.cpp
+++ b/aq_network.cpp
@@ -1,0 +1,338 @@
+#include "Arduino.h"
+
+// hardware and internet configuration parameters
+#include "config.h"
+// private credentials for network, MQTT, weather provider
+#include "secrets.h"
+
+// Shared helper function we call here too...
+extern void debugMessage(String messageText);
+
+// Includes and defines specific to WiFi network connectivity
+#ifdef WIFI
+  #if defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT) || defined(ARDUINO_AVR_UNO_WIFI_REV2)
+    #include <WiFiNINA.h>
+  #elif defined(ARDUINO_SAMD_MKR1000)
+    #include <WiFi101.h>
+  #elif defined(ARDUINO_ESP8266_ESP12)
+    #include <ESP8266WiFi.h>
+  #else
+    #include <WiFi.h>
+  #endif
+
+  WiFiClient client;
+  //WiFiClientSecure client; // for SSL
+
+  // NTP support
+  #include <WiFiUdp.h>
+  WiFiUDP ntpUDP;
+#endif
+
+// Includes and defines specific to Ethernet (wired) network connectivity
+#ifdef RJ45
+  // Set MAC address. If unknown, be careful for duplicate addresses across projects.
+  byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };
+  #include <SPI.h>
+  #include <Ethernet.h>
+  EthernetClient client;
+
+  // NTP support
+  #include <EthernetUdp.h>
+  EthernetUDP ntpUDP;
+#endif
+
+// Network services independent of physiccal connection
+#if defined(WIFI) || defined(RJ45)
+  // NTP setup
+  #include <NTPClient.h>
+  NTPClient timeClient(ntpUDP);
+  
+  // Generalized access to HTTP services atop WiFi or Ethernet connections
+  #include <HTTPClient.h> 
+#endif
+
+// Converts system time into human readable strings. Depends on NTP service access
+String dateTimeString()
+{
+  #if defined(WIFI) || defined(RJ45)
+    String dateTime;
+    String weekDays[7]={"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
+  
+    if (timeClient.update())
+    {
+      // NTPClient doesn't include date information, get it from time structure
+      time_t epochTime = timeClient.getEpochTime();
+      struct tm *ptm = gmtime ((time_t *)&epochTime);
+      int day = ptm->tm_mday;
+      int month = ptm->tm_mon+1;
+      int year = ptm->tm_year+1900;
+  
+      dateTime = weekDays[timeClient.getDay()];
+      dateTime += ",";
+  
+      if (month<10) dateTime += "0";
+      dateTime += month;
+      dateTime += "-";
+      if (day<10) dateTime += "0";
+      dateTime += day;
+      dateTime += " at ";
+      if (timeClient.getHours()<10) dateTime += "0";
+      dateTime += timeClient.getHours();
+      dateTime += ":";
+      if (timeClient.getMinutes()<10) dateTime += "0";
+      dateTime += timeClient.getMinutes();
+  
+      // zulu format
+      // dateTime = year + "-";
+      // if (month()<10) dateTime += "0";
+      // dateTime += month;
+      // dateTime += "-";
+      // if (day()<10) dateTime += "0";
+      // dateTime += day;
+      // dateTime += "T";
+      // if (timeClient.getHours()<10) dateTime += "0";
+      // dateTime += timeClient.getHours();
+      // dateTime += ":";
+      // if (timeClient.getMinutes()<10) dateTime += "0";
+      // dateTime += timeClient.getMinutes();
+      // dateTime += ":";
+      // if (timeClient.getSeconds()<10) dateTime += "0";
+      // dateTime += timeClient.getSeconds();
+      // switch (timeZone)
+      // {
+      //   case 0:
+      //     dateTime += "Z";
+      //     break;
+      //   case -7:
+      //     dateTime += "PDT";
+      //     break;
+      //   case -8:
+      //     dateTime += "PST";
+      //     break;     
+      // }
+    }
+    else {
+      dateTime ="Time not set";
+    }
+  #else
+    // If no network defined
+    dateTime ="No time service";
+  #endif
+  
+  return dateTime;
+}
+
+// Initialize network and connect.  If connection succeeds initialize NTP connection so
+// device can report accurate local time.  Returns boolean indicating whether network is
+// connected and available.  Depends on configuration #defines in config.h to determine
+// what network hardware is attached, and key network settings there as well (e.g. SSID).
+bool networkBegin()
+{
+  bool networkAvailable = false;
+  
+  #ifdef WIFI
+    uint8_t tries;
+    #define MAX_TRIES 5
+  
+    // set hostname has to come before WiFi.begin
+    WiFi.hostname(CLIENT_ID);
+    // WiFi.setHostname(CLIENT_ID); //for WiFiNINA
+    
+    // Connect to WiFi.  Prepared to wait a reasonable interval for the connection to
+    // succeed, but not forever.  Will check status and, if not connected, delay an
+    // increasing amount of time up to a maximum of MAX_TRIES delay intervals. 
+    WiFi.begin(WIFI_SSID, WIFI_PASS);
+    
+    for(tries=1;tries<=MAX_TRIES;tries++) 
+    {
+      debugMessage(String("Connection attempt ") + tries + " of " + MAX_TRIES + " to " + WIFI_SSID + " in " + (tries*10) + " seconds");
+      if(WiFi.status() == WL_CONNECTED) 
+      {
+        // Successful connection!
+        networkAvailable = true;
+        break;
+      }
+      // use of delay OK as this is initialization code
+      delay(tries*10000);   // Waiting longer each time we check for status
+    }
+    if(networkAvailable)
+    {
+      debugMessage("WiFi IP address is: " + WiFi.localIP().toString());
+      debugMessage("RSSI is: " + String(WiFi.RSSI()) + " dBm");  
+    }
+    else
+    {
+      // Couldn't connect, alas
+      debugMessage(String("Can not connect to WFii after ") + MAX_TRIES + " attempts");   
+    }
+  #endif
+
+  #ifdef RJ45
+    // Configure Ethernet CS pin, not needed if using default D10
+    //Ethernet.init(10);  // Most Arduino shields
+    //Ethernet.init(5);   // MKR ETH shield
+    //Ethernet.init(0);   // Teensy 2.0
+    //Ethernet.init(20);  // Teensy++ 2.0
+    //Ethernet.init(15);  // ESP8266 with Adafruit Featherwing Ethernet
+    //Ethernet.init(33);  // ESP32 with Adafruit Featherwing Ethernet
+  
+    // Initialize Ethernet and UDP
+    if (Ethernet.begin(mac) == 0)
+    {
+      // identified errors
+      if (Ethernet.hardwareStatus() == EthernetNoHardware)
+      {
+        debugMessage("Ethernet hardware not found");
+      }
+      else if (Ethernet.linkStatus() == LinkOFF)
+      {
+        debugMessage("Ethernet cable not connected");
+      }
+      else
+      {
+        // generic error
+        debugMessage("Failed to configure Ethernet");
+      }
+    }
+    else
+    {
+      debugMessage(String("Ethernet IP address is: ") + Ethernet.localIP().toString()));
+      networkAvailable = true;
+    }
+  #endif
+  
+  #if defined(WIFI) || defined(RJ45)
+    if(networkAvailable) {
+      // Get time from NTP
+      timeClient.begin();
+      // Set offset time in seconds to adjust for your timezone
+      timeClient.setTimeOffset(timeZone*60*60);
+      debugMessage("NTP time: " + dateTimeString());
+    }
+  #endif
+  
+  return(networkAvailable);
+}
+
+
+String httpGETRequest(const char* serverName) 
+{
+  String payload = "{}";
+  
+  #if defined(WIFI) || defined(RJ45)
+    HTTPClient http;
+    
+    // servername is domain name w/URL path or IP address w/URL path
+    http.begin(client, serverName);
+  
+    // Send HTTP GET request
+    int httpResponseCode = http.GET();
+  
+    if (httpResponseCode>0)
+    {
+      debugMessage("HTTP Response code: " + httpResponseCode);
+      payload = http.getString();
+    }
+    else
+    {
+      debugMessage("Error code: " + httpResponseCode);
+    }
+    // free resources
+    http.end();
+  #endif
+  return payload;
+}
+
+void networkStop()
+{
+  #if defined(WIFI) || defined(RJ45)
+    client.stop();
+  #endif
+}
+
+int httpPOSTRequest(String serverurl, String contenttype, String payload)
+{
+  int httpCode = -1;
+  #if defined(WIFI) || defined(RJ45)
+    HTTPClient http;
+  
+    http.begin(client,serverurl);  
+    http.addHeader("Content-Type", contenttype);
+    
+    httpCode = http.POST(payload);
+    
+    // httpCode will be negative on error, but HTTP status might indicate failure
+    if (httpCode > 0) {
+      // HTTP POST complete, print result code
+      debugMessage("HTTP POST [" + serverurl + "], result code: " + String(httpCode) );
+  
+      // If POST succeeded, output response as debug messages
+      if (httpCode == HTTP_CODE_OK) {
+        const String& payload = http.getString();
+        debugMessage("received payload:\n<<");
+        debugMessage(payload);
+        debugMessage(">>");
+      }
+    } 
+    else {
+      debugMessage("HTTP POST [" + serverurl + "] failed, error: " + http.errorToString(httpCode).c_str());
+    }
+  
+    http.end();
+    debugMessage("closing connection for dweeting");
+  #endif
+  
+  return(httpCode);
+}
+
+// Utility functions that may be of use
+
+// Return local IP address as a String
+String getLocalIPString()
+{
+  #if defined(WIFI) || defined(RJ45)
+    return(client.localIP().toString());
+  #else
+    return("No network");
+  #endif
+}
+
+// Return RSSI for WiFi network, simulate out-of-range value for non-WiFi
+long getWiFiRSSI()
+{
+  #ifdef WIFI
+    return(WiFi.RSSI());
+  #else
+    return(-255);  //Arbitrary out-of-range value
+  #endif
+}
+
+// Returns true if WIFI defined in config.h, otherwise false
+bool isWireless()
+{
+  #ifdef WIFI
+    return(true);
+  #else
+    return(false);
+  #endif
+}
+
+// Returns true if RJ45 (Ethernet) defined in config.h, otherwise false
+bool isWired()
+{
+  #ifdef RJ45
+    return(true);
+  #else
+    return(false);
+  #endif
+}
+
+// Returns connection status (via Client class), or false if no network defined in config.h
+bool isConnected()
+{
+  #if defined(WIFI) || defined(RJ45)
+    return(client.connected());
+  #else
+    return(false);
+  #endif
+}

--- a/aq_network.h
+++ b/aq_network.h
@@ -1,0 +1,21 @@
+#ifndef AQNetwork_h
+#define AQNetwork_h
+
+#include "Arduino.h"
+
+class AQ_Network {
+  public:
+    bool networkBegin();
+    void networkStop();
+    String dateTimeString();
+    String httpGETRequest(const char* serverName);
+    int httpPOSTRequest(String serverurl, String contenttype, String payload);
+    String getLocalIPString();
+    long getWiFiRSSI();
+    bool isWireless();
+    bool isWired();
+    bool isConnected();
+  private:
+};
+
+#endif

--- a/config.h
+++ b/config.h
@@ -2,9 +2,9 @@
 //#define DEBUG     // Output to serial port
 //#define RJ45    // use Ethernet
 #define WIFI    // use WiFi
-#define MQTTLOG // log sensor data to MQTT broker
-//#define DWEET     // Post sensor readings to dweet.io
-//#define INFLUX  // Log data to remote InfluxDB server
+//#define MQTTLOG // log sensor data to MQTT broker
+#define DWEET     // Post sensor readings to dweet.io
+#define INFLUX  // Log data to remote InfluxDB server
 
 // set logging interval in minutes
 #ifdef DEBUG
@@ -84,7 +84,8 @@ const int timeZone = -7;  // USA PDT
 
 #ifdef INFLUX
 	// Tags values for InfluxDB data points.  Should be customized to match your 
-	// InfluxDB data model, and can add more here and in post_influx.cpp if desired
+	// InfluxDB data model, and can add more here and in post_influx.cpp if desired.
+  // Server URL and access credentials are specified in secrets.h
 	#define DEVICE_NAME "airquality"
 	#define DEVICE_LOCATION "dining room"
 	#define DEVICE_SITE "indoor"

--- a/config.h
+++ b/config.h
@@ -4,7 +4,7 @@
 #define WIFI    // use WiFi
 //#define MQTTLOG // log sensor data to MQTT broker
 #define DWEET     // Post sensor readings to dweet.io
-#define INFLUX  // Log data to remote InfluxDB server
+//#define INFLUX  // Log data to remote InfluxDB server
 
 // set logging interval in minutes
 #ifdef DEBUG

--- a/post_dweet.cpp
+++ b/post_dweet.cpp
@@ -5,13 +5,16 @@
 // private credentials for network, MQTT, weather provider
 #include "secrets.h"
 
+#include "aq_network.h"
+extern AQ_Network aq_network;
+
 
 #ifdef DWEET
 #include <HTTPClient.h> 
 
 // Shared helper function we call here too...
 extern void debugMessage(String messageText);
-extern int httpPOSTRequest(String serverurl, String contenttype, String payload);
+// extern int httpPOSTRequest(String serverurl, String contenttype, String payload);
 extern bool batteryAvailable;
 extern bool internetAvailable;
 
@@ -54,7 +57,7 @@ void post_dweet(uint16_t co2, float tempF, float humidity, float battpct, float 
                        "\"humidity\":\""    + String(humidity, 2)      + "\"}";
 
   String postdata = device_info + battery_info + sensor_info;
-  int httpCode = httpPOSTRequest(dweeturl,"application/json",postdata);
+  int httpCode = aq_network.httpPOSTRequest(dweeturl,"application/json",postdata);
   
   // httpCode will be negative on error, but HTTP status might indicate failure
   if (httpCode > 0) {

--- a/post_dweet.cpp
+++ b/post_dweet.cpp
@@ -1,0 +1,67 @@
+#include "Arduino.h"
+
+// hardware and internet configuration parameters
+#include "config.h"
+// private credentials for network, MQTT, weather provider
+#include "secrets.h"
+
+
+#ifdef DWEET
+#include <HTTPClient.h> 
+
+// Shared helper function we call here too...
+extern void debugMessage(String messageText);
+extern int httpPOSTRequest(String serverurl, String contenttype, String payload);
+extern bool batteryAvailable;
+extern bool internetAvailable;
+
+// Post a dweet to report the various sensor reading.  This routine blocks while
+// talking to the network, so may take a while to execute.
+void post_dweet(uint16_t co2, float tempF, float humidity, float battpct, float battv)
+{
+
+  /*
+  if(WiFi.status() != WL_CONNECTED) {
+    debugMessage("Lost network connection to '" + String(WIFI_SSID) + "'!");
+    // show_disconnected();  / Future feature to display state of network connectivity (LED?)
+    return;
+  }
+  debugMessage("connecting to " + String(DWEET_HOST));
+  */
+
+  String dweeturl = "http://" + String(DWEET_HOST) + "/dweet/for/" + String(DWEET_DEVICE);
+
+  /*
+  // Use HTTP class to publish dweet
+  HTTPClient dweetio;
+  dweetio.begin(client,dweeturl);  
+  dweetio.addHeader("Content-Type", "application/json");
+  */
+
+  // Use HTTP post and send a data payload as JSON
+  String device_info = "{\"rssi\":\""   + String(WiFi.RSSI())        + "\"," +
+                       "\"ipaddr\":\"" + WiFi.localIP().toString()  + "\",";
+  String battery_info;
+  if(batteryAvailable) {
+    battery_info = "\"battery_percent\":\"" + String(battpct) + "\"," +
+                   "\"battery_voltage\":\"" + String(battv)   + "\",";
+  }
+  else {
+    battery_info = "";
+  }
+  String sensor_info = "\"co2\":\""         + String(co2)             + "\"," +
+                       "\"temperature\":\"" + String(tempF, 2)         + "\"," +
+                       "\"humidity\":\""    + String(humidity, 2)      + "\"}";
+
+  String postdata = device_info + battery_info + sensor_info;
+  int httpCode = httpPOSTRequest(dweeturl,"application/json",postdata);
+  
+  // httpCode will be negative on error, but HTTP status might indicate failure
+  if (httpCode > 0) {
+    // HTTP POST complete, print result code
+    debugMessage("HTTP POST [dweet.io], result code: " + String(httpCode) );
+  } else {
+    debugMessage("HTTP POST [dweet.io] failed, result code: " + String(httpCode));
+  }
+}
+#endif

--- a/post_influx.cpp
+++ b/post_influx.cpp
@@ -19,10 +19,11 @@ InfluxDBClient dbclient(INFLUXDB_URL, INFLUXDB_DB_NAME);
 
 // InfluxDB Data point, binds to InfluxDB 'measurement' to use for data
 Point dbenvdata("weather");
+Point dbdevdata("device");   // Device data, esp. battery status
 
 // Post data to Influx DB using the connection established during setup
 // Operates over the network, so may take a while to execute.
-void post_influx(uint16_t co2, float tempF, float humidity)
+void post_influx(uint16_t co2, float tempF, float humidity, float battery_p, float battery_v)
 {
   Serial.println("Saving data to Influx");
   // Set InfluxDB 1 authentication params using values defined in secrets.h
@@ -30,9 +31,15 @@ void post_influx(uint16_t co2, float tempF, float humidity)
   
   // Add constant Influx data point tags - only do once, will be added to all individual data points
   // Modify if required to reflect your InfluxDB data model (and set values in config.h)
+  // Tags for environmental data (weather)
   dbenvdata.addTag("device", DEVICE_NAME);
   dbenvdata.addTag("location", DEVICE_LOCATION);
   dbenvdata.addTag("site", DEVICE_SITE);
+
+  // Tags for device data (especially battery status)
+  dbdevdata.addTag("device", DEVICE_NAME);
+  dbdevdata.addTag("location", DEVICE_LOCATION);
+  dbdevdata.addTag("site", DEVICE_SITE);
 
   // If confirmed connection to InfluxDB server, store our data values (with retries)
   boolean dbsuccess = false;
@@ -50,7 +57,8 @@ void post_influx(uint16_t co2, float tempF, float humidity)
     return;
   }
   else {
-    // Connected, so store measured values into timeseries data point
+    // Connected, so store measured values into timeseries data point(s)
+    // First, the sensor (weather) data
     dbenvdata.clearFields();
     // Report sensor readings
     dbenvdata.addField("temperature", tempF);
@@ -61,6 +69,18 @@ void post_influx(uint16_t co2, float tempF, float humidity)
     if (!dbclient.writePoint(dbenvdata)) {
       debugMessage("InfluxDB write failed: " + dbclient.getLastErrorMessage());
     }
+    // Then the device data (device)
+    dbdevdata.clearFields();
+    // Report device readings
+    dbdevdata.addField("battery_pct", battery_p);
+    dbdevdata.addField("battery_volts", battery_v);
+    // dbdevdata.addField("rssi", rssi);
+    debugMessage("Writing: " + dbclient.pointToLineProtocol(dbdevdata));
+    // Write point via connection to InfluxDB host
+    if (!dbclient.writePoint(dbdevdata)) {
+      debugMessage("InfluxDB device write failed: " + dbclient.getLastErrorMessage());
+     }
+    
     dbclient.flushBuffer();  // Clear pending writes (before going to sleep)
   }
 }


### PR DESCRIPTION
Rearranged the networking code that had been in the main sketch file (air_quality.ino) so it's in a separate file as a class. This eliminates the need for all the #ifdefs in the main sketch that handled wifi vs. ethernet.  All the necessary code for both wifi and ethernet is now implemented in a separate AQ_Network class that handles network differences internally, substantially simplifying the structure of the main sketch.  That new class and all those ifdefs are now just in aq_network.cpp (and aq_network.h).

At the same time I modified post_dweet() so it used the generalized network class interface, cleaning up that code and yielding a version that works for both wifi and ethernet (when the previous version only worked with wifi).

