### PR TITLE
Store battery voltage, RSSI to services

### DIFF
--- a/air_quality.ino
+++ b/air_quality.ino
@@ -84,11 +84,11 @@ ThinkInk_290_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY)
 #include "ArduinoJson.h"  // Needed by getWeather()
 
 #ifdef INFLUX
-extern boolean post_influx(uint16_t co2, float tempF, float humidity, float battery_p, float battery_v);
+extern boolean post_influx(uint16_t co2, float tempF, float humidity, float battery_p, float battery_v, int rssi);
 #endif
 
 #ifdef DWEET
-extern void post_dweet(uint16_t co2, float tempF, float humidity, float battpct, float battv);
+extern void post_dweet(uint16_t co2, float tempF, float humidity, float battpct, float battv, int rssi);
 #endif
 
 #ifdef MQTTLOG
@@ -229,13 +229,13 @@ void setup()
     #endif
 
     #ifdef DWEET
-      post_dweet(averageCO2, averageTempF, averageHumidity, battpct, battv);
+      post_dweet(averageCO2, averageTempF, averageHumidity, battpct, battv, rssi);
       upd_flags += "D";
     #endif
 
     #ifdef INFLUX
       // Returns true if successful
-      if (post_influx(averageCO2, averageTempF, averageHumidity, battpct, battv)) {
+      if (post_influx(averageCO2, averageTempF, averageHumidity, battpct, battv, rssi)) {
         upd_flags += "I";
       }
     #endif

--- a/air_quality.ino
+++ b/air_quality.ino
@@ -93,7 +93,7 @@ extern void post_dweet(uint16_t co2, float tempF, float humidity, float battpct,
 
 #ifdef MQTTLOG
 extern void mqttConnect();
-extern int mqttBatteryUpdate(float cellPercent);
+extern int mqttDeviceInfoUpdate(float cellPercent, float cellVoltage, int rssi);
 extern int mqttSensorUpdate(uint16_t co2, float tempF, float humidity);
 #endif
 
@@ -200,35 +200,45 @@ void setup()
 
   String upd_flags = "";  // To indicate whether services succeeded
   if (internetAvailable)
-  // and internet is verified
   {
-#ifdef MQTTLOG
-    int sensor_pub = 0;
-    int batt_pub = 0;
-    sensor_pub = mqttSensorUpdate(averageCO2, averageTempF, averageHumidity);
-    batt_pub = mqttBatteryUpdate(lc.cellPercent());
-    if (sensor_pub && batt_pub) {
-      upd_flags += "M";
+    float battpct, battv;
+    int rssi;
+
+    rssi = aq_network.getWiFiRSSI();
+
+    if (batteryAvailable)
+    {
+      battpct = lc.cellPercent(); // buffered to prevent issues associated with repeated calls within short time
+      battv = lc.cellVoltage();
     }
-#endif
-
-  float battpct, battv;
-#ifdef DWEET
-    battpct = lc.cellPercent();
-    battv = lc.cellVoltage();
-    post_dweet(averageCO2, averageTempF, averageHumidity, battpct, battv);
-    upd_flags += "D";
-#endif
-
-
-#ifdef INFLUX
-    battpct = lc.cellPercent();
-    battv = lc.cellVoltage();
-    // Returns true if successful
-    if (post_influx(averageCO2, averageTempF, averageHumidity, battpct, battv)) {
-      upd_flags += "I";
+    else
+    {
+      // Error values
+      battpct = 10000;
+      battv = 10000;
     }
-#endif
+
+    #ifdef MQTTLOG
+      int sensor_pub = 0;
+      int device_pub = 0;
+      sensor_pub = mqttSensorUpdate(averageCO2, averageTempF, averageHumidity);
+      device_pub = mqttDeviceInfoUpdate(battpct, battv, rssi);
+      if (sensor_pub && device_pub) {
+        upd_flags += "M";
+      }
+    #endif
+
+    #ifdef DWEET
+      post_dweet(averageCO2, averageTempF, averageHumidity, battpct, battv);
+      upd_flags += "D";
+    #endif
+
+    #ifdef INFLUX
+      // Returns true if successful
+      if (post_influx(averageCO2, averageTempF, averageHumidity, battpct, battv)) {
+        upd_flags += "I";
+      }
+    #endif
   }
 
   // Update the screen if available

--- a/aq_network.cpp
+++ b/aq_network.cpp
@@ -148,7 +148,6 @@ bool AQ_Network::networkBegin()
   
   #ifdef WIFI
     uint8_t tries;
-    #define MAX_TRIES 5
   
     // set hostname has to come before WiFi.begin
     WiFi.hostname(CLIENT_ID);
@@ -156,12 +155,12 @@ bool AQ_Network::networkBegin()
     
     // Connect to WiFi.  Prepared to wait a reasonable interval for the connection to
     // succeed, but not forever.  Will check status and, if not connected, delay an
-    // increasing amount of time up to a maximum of MAX_TRIES delay intervals. 
+    // increasing amount of time up to a maximum of WIFI_ATTEMPT_LIMIT delay intervals. 
     WiFi.begin(WIFI_SSID, WIFI_PASS);
     
-    for(tries=1;tries<=MAX_TRIES;tries++) 
+    for(tries=1;tries<=WIFI_ATTEMPT_LIMIT;tries++) 
     {
-      debugMessage(String("Connection attempt ") + tries + " of " + MAX_TRIES + " to " + WIFI_SSID + " in " + (tries*10) + " seconds");
+      debugMessage(String("Connection attempt ") + tries + " of " + WIFI_ATTEMPT_LIMIT + " to " + WIFI_SSID + " in " + (tries*10) + " seconds");
       if(WiFi.status() == WL_CONNECTED) 
       {
         // Successful connection!
@@ -174,12 +173,12 @@ bool AQ_Network::networkBegin()
     if(networkAvailable)
     {
       debugMessage("WiFi IP address is: " + WiFi.localIP().toString());
-      debugMessage("RSSI is: " + String(WiFi.RSSI()) + " dBm");  
+      debugMessage("RSSI is: " + String(getWiFiRSSI()) + " dBm");  
     }
     else
     {
       // Couldn't connect, alas
-      debugMessage(String("Can not connect to WFii after ") + MAX_TRIES + " attempts");   
+      debugMessage(String("Can not connect to WFii after ") + WIFI_ATTEMPT_LIMIT + " attempts");   
     }
   #endif
 
@@ -212,7 +211,7 @@ bool AQ_Network::networkBegin()
     }
     else
     {
-      debugMessage(String("Ethernet IP address is: ") + Ethernet.localIP().toString()));
+      debugMessage(String("Ethernet IP address is: ") + Ethernet.localIP().toString());
       networkAvailable = true;
     }
   #endif
@@ -315,7 +314,7 @@ String AQ_Network::getLocalIPString()
 }
 
 // Return RSSI for WiFi network, simulate out-of-range value for non-WiFi
-long AQ_Network::getWiFiRSSI()
+int AQ_Network::getWiFiRSSI()
 {
   #ifdef WIFI
     return(WiFi.RSSI());

--- a/aq_network.h
+++ b/aq_network.h
@@ -11,7 +11,7 @@ class AQ_Network {
     String httpGETRequest(const char* serverName);
     int httpPOSTRequest(String serverurl, String contenttype, String payload);
     String getLocalIPString();
-    long getWiFiRSSI();
+    int getWiFiRSSI();
     bool isWireless();
     bool isWired();
     bool isConnected();

--- a/config.h
+++ b/config.h
@@ -43,18 +43,19 @@ const int timeZone = -7;  // USA PDT
 // based on a settings curve in the LC709203F datasheet
 // #define BATTERY_APA 0x08 // 100mAH
 // #define BATTERY_APA 0x0B // 200mAH
-#define BATTERY_APA 0x10 // 500mAH
+// #define BATTERY_APA 0x10 // 500mAH
 // #define BATTERY_APA 0x19 // 1000mAH
 // #define BATTERY_APA 0x1D // 1200mAH
-//#define BATTERY_APA 0x2D // 2000mAH
-//#define BATTERY_APA 0x32 // 2500mAH
+#define BATTERY_APA 0x2D // 2000mAH
+// #define BATTERY_APA 0x32 // 2500mAH
 // #define BATTERY_APA 0x36 // 3000mAH
 
 // set client ID; used by mqtt and wifi
 //#define CLIENT_ID "AQ-test-room"
-#define CLIENT_ID "AQ-lab-office"
+//#define CLIENT_ID "AQ-lab-office"
 //#define CLIENT_ID "AQ-kitchen"
-//#define CLIENT_ID "AQ-cellar"
+#define CLIENT_ID "AQ-cellar"
+//#define CLIENT_ID "AQ-master-bedroom"
 
 #ifdef MQTTLOG
 	// set MQTT parameters
@@ -64,28 +65,36 @@ const int timeZone = -7;  // USA PDT
 	// #define MQTT_PUB_TOPIC2		"sircoolio/feeds/pocket-office.humidity"
 	// #define MQTT_PUB_TOPIC3		"sircoolio/feeds/pocket-office.co2"
 	// #define MQTT_PUB_TOPIC4		"sircoolio/feeds/pocket-office.battery-level"
+	// #define MQTT_PUB_TOPIC5		"sircoolio/feeds/pocket-office.battery-voltage"
+	// #define MQTT_PUB_TOPIC6		"sircoolio/feeds/pocket-office.rssi"
 
 	// #define MQTT_PUB_TOPIC1		"sircoolio/feeds/master-bedroom.temperature"
 	// #define MQTT_PUB_TOPIC2		"sircoolio/feeds/master-bedroom.humidity"
 	// #define MQTT_PUB_TOPIC3		"sircoolio/feeds/master-bedroom.co2"
 	// #define MQTT_PUB_TOPIC4		"sircoolio/feeds/master-bedroom.battery-level"
+	// #define MQTT_PUB_TOPIC5		"sircoolio/feeds/master-bedroom.battery-voltage"
+	// #define MQTT_PUB_TOPIC6		"sircoolio/feeds/master-bedroom.rssi"
 
-	#define MQTT_PUB_TOPIC1		"sircoolio/feeds/lab-office.temperature"
-	#define MQTT_PUB_TOPIC2		"sircoolio/feeds/lab-office.humidity"
-	#define MQTT_PUB_TOPIC3		"sircoolio/feeds/lab-office.co2"
-	#define MQTT_PUB_TOPIC4		"sircoolio/feeds/lab-office.battery-level"
-	#define MQTT_PUB_TOPIC5		"sircoolio/feeds/lab-office.battery-voltage"
-	#define MQTT_PUB_TOPIC6		"sircoolio/feeds/lab-office.rssi"
+	// #define MQTT_PUB_TOPIC1		"sircoolio/feeds/lab-office.temperature"
+	// #define MQTT_PUB_TOPIC2		"sircoolio/feeds/lab-office.humidity"
+	// #define MQTT_PUB_TOPIC3		"sircoolio/feeds/lab-office.co2"
+	// #define MQTT_PUB_TOPIC4		"sircoolio/feeds/lab-office.battery-level"
+	// #define MQTT_PUB_TOPIC5		"sircoolio/feeds/lab-office.battery-voltage"
+	// #define MQTT_PUB_TOPIC6		"sircoolio/feeds/lab-office.rssi"
 
 	// #define MQTT_PUB_TOPIC1		"sircoolio/feeds/kitchen.temperature"
 	// #define MQTT_PUB_TOPIC2		"sircoolio/feeds/kitchen.humidity"
 	// #define MQTT_PUB_TOPIC3		"sircoolio/feeds/kitchen.co2"
 	// #define MQTT_PUB_TOPIC4		"sircoolio/feeds/kitchen.battery-level"
+	// #define MQTT_PUB_TOPIC5		"sircoolio/feeds/kitchen.battery-voltage"
+	// #define MQTT_PUB_TOPIC6		"sircoolio/feeds/kitchen.rssi"
 
-	// #define MQTT_PUB_TOPIC1		"sircoolio/feeds/cellar.temperature"
-	// #define MQTT_PUB_TOPIC2		"sircoolio/feeds/cellar.humidity"
-	// #define MQTT_PUB_TOPIC3		"sircoolio/feeds/cellar.co2"
-	// #define MQTT_PUB_TOPIC4		"sircoolio/feeds/cellar.battery-level"
+	#define MQTT_PUB_TOPIC1		"sircoolio/feeds/cellar.temperature"
+	#define MQTT_PUB_TOPIC2		"sircoolio/feeds/cellar.humidity"
+	#define MQTT_PUB_TOPIC3		"sircoolio/feeds/cellar.co2"
+	#define MQTT_PUB_TOPIC4		"sircoolio/feeds/cellar.battery-level"
+	#define MQTT_PUB_TOPIC5		"sircoolio/feeds/cellar.battery-voltage"
+	#define MQTT_PUB_TOPIC6		"sircoolio/feeds/cellar.rssi"
 
 	// #define MQTT_PUB_TOPIC1		"sircoolio/feeds/test-room.temperature"
 	// #define MQTT_PUB_TOPIC2		"sircoolio/feeds/test-room.humidity"
@@ -98,6 +107,9 @@ const int timeZone = -7;  // USA PDT
 	// #define MQTT_PUB_TOPIC2		"sircoolio/feeds/test-headless.humidity"
 	// #define MQTT_PUB_TOPIC3		"sircoolio/feeds/test-headless.co2"
 	// #define MQTT_PUB_TOPIC4		"sircoolio/feeds/test-headless.battery-level"
+	// #define MQTT_PUB_TOPIC5		"sircoolio/feeds/test-headless.battery-voltage"
+	// #define MQTT_PUB_TOPIC6		"sircoolio/feeds/test-headless.rssi"
+
 #endif
 
 #ifdef INFLUX  
@@ -110,8 +122,10 @@ const int timeZone = -7;  // USA PDT
   // the house) and site (indoors vs. outdoors, typically).
 	//#define DEVICE_LOCATION "test room"
 	//#define DEVICE_LOCATION "kitchen"
-	//#define DEVICE_LOCATION "cellar"
-	#define DEVICE_LOCATION "lab-office"
+	#define DEVICE_LOCATION "cellar"
+	//#define DEVICE_LOCATION "lab-office"
+	//#define DEVICE_LOCATION "master bedroom"
+
 	#define DEVICE_SITE "indoor"
 	#define DEVICE_TYPE "air quality"
 

--- a/config.h
+++ b/config.h
@@ -133,7 +133,9 @@ const int timeZone = -7;  // USA PDT
 
 // 	Open Weather Map
 // 	#define OWM_KEY
-//	#define OWM_LAT_LONG
+//	#define OWM_LAT_LONG  // example "lat=47.9001&lon=-122.4001"
+
+//	#define SITE_ELEVATION // in meters
 
 // If MQTT enabled
 // 	#define MQTT_PORT

--- a/config.h
+++ b/config.h
@@ -1,9 +1,9 @@
 // conditional compile flags
-//#define DEBUG 	// Output to serial port
+#define DEBUG 	// Output to serial port
 //#define RJ45  	// use Ethernet
 #define WIFI    	// use WiFi
 #define MQTTLOG 	// log sensor data to MQTT broker
-//#define DWEET     // Post sensor readings to dweet.io
+#define DWEET     // Post sensor readings to dweet.io
 #define INFLUX  	// Log data to remote InfluxDB server
 #define	SCREEN		// use screen as output
 
@@ -15,18 +15,17 @@
 #endif
 // number of samples captured before logging
 #ifdef DEBUG
-  #define SAMPLE_SIZE 2 // do not set to 1, GitHub issue #54
+  #define SAMPLE_SIZE 1
 #else
   #define SAMPLE_SIZE 6
 #endif
+
+#define WIFI_ATTEMPT_LIMIT	5 // max connection attempts to WiFi AP
+
 // millisecond modifier to minutes for sampling interval (ARM)
 // #define SAMPLE_INTERVAL_ARM_MODIFIER 60000
 // microsecond modifier to minutes for sampling interval (ESP)
 #define SAMPLE_INTERVAL_ESP_MODIFIER 60000000
-
-// set client ID; used by mqtt and wifi
-//#define CLIENT_ID "AQ-test-room"
-#define CLIENT_ID "AQ-lab-office"
 
 // Open Weather Map parameters
 #define OWM_SERVER			"http://api.openweathermap.org/data/2.5/"
@@ -44,16 +43,22 @@ const int timeZone = -7;  // USA PDT
 // based on a settings curve in the LC709203F datasheet
 // #define BATTERY_APA 0x08 // 100mAH
 // #define BATTERY_APA 0x0B // 200mAH
-#define BATTERY_APA 0x10 // 500mAH
+//#define BATTERY_APA 0x10 // 500mAH
 // #define BATTERY_APA 0x19 // 1000mAH
 // #define BATTERY_APA 0x1D // 1200mAH
-// #define BATTERY_APA 0x2D // 2000mAH
+#define BATTERY_APA 0x2D // 2000mAH
 //#define BATTERY_APA 0x32 // 2500mAH
 // #define BATTERY_APA 0x36 // 3000mAH
 
+// set client ID; used by mqtt and wifi
+#define CLIENT_ID "AQ-test-room"
+//#define CLIENT_ID "AQ-lab-office"
+//#define CLIENT_ID "AQ-kitchen"
+//#define CLIENT_ID "AQ-cellar"
+
 #ifdef MQTTLOG
 	// set MQTT parameters
-	#define MQTT_ATTEMPT_LIMIT 	3 	// number of connection attempts for MQTT broker
+	#define MQTT_ATTEMPT_LIMIT 	3 	// max connection attempts to MQTT broker
 
 	// #define MQTT_PUB_TOPIC1		"sircoolio/feeds/pocket-office.temperature"
 	// #define MQTT_PUB_TOPIC2		"sircoolio/feeds/pocket-office.humidity"
@@ -65,10 +70,10 @@ const int timeZone = -7;  // USA PDT
 	// #define MQTT_PUB_TOPIC3		"sircoolio/feeds/master-bedroom.co2"
 	// #define MQTT_PUB_TOPIC4		"sircoolio/feeds/master-bedroom.battery-level"
 
-	#define MQTT_PUB_TOPIC1		"sircoolio/feeds/lab-office.temperature"
-	#define MQTT_PUB_TOPIC2		"sircoolio/feeds/lab-office.humidity"
-	#define MQTT_PUB_TOPIC3		"sircoolio/feeds/lab-office.co2"
-	#define MQTT_PUB_TOPIC4		"sircoolio/feeds/lab-office.battery-level"
+	// #define MQTT_PUB_TOPIC1		"sircoolio/feeds/lab-office.temperature"
+	// #define MQTT_PUB_TOPIC2		"sircoolio/feeds/lab-office.humidity"
+	// #define MQTT_PUB_TOPIC3		"sircoolio/feeds/lab-office.co2"
+	// #define MQTT_PUB_TOPIC4		"sircoolio/feeds/lab-office.battery-level"
 
 	// #define MQTT_PUB_TOPIC1		"sircoolio/feeds/kitchen.temperature"
 	// #define MQTT_PUB_TOPIC2		"sircoolio/feeds/kitchen.humidity"
@@ -80,10 +85,12 @@ const int timeZone = -7;  // USA PDT
 	// #define MQTT_PUB_TOPIC3		"sircoolio/feeds/cellar.co2"
 	// #define MQTT_PUB_TOPIC4		"sircoolio/feeds/cellar.battery-level"
 
-	// #define MQTT_PUB_TOPIC1		"sircoolio/feeds/test-room.temperature"
-	// #define MQTT_PUB_TOPIC2		"sircoolio/feeds/test-room.humidity"
-	// #define MQTT_PUB_TOPIC3		"sircoolio/feeds/test-room.co2"
-	// #define MQTT_PUB_TOPIC4		"sircoolio/feeds/test-room.battery-level"
+	#define MQTT_PUB_TOPIC1		"sircoolio/feeds/test-room.temperature"
+	#define MQTT_PUB_TOPIC2		"sircoolio/feeds/test-room.humidity"
+	#define MQTT_PUB_TOPIC3		"sircoolio/feeds/test-room.co2"
+	#define MQTT_PUB_TOPIC4		"sircoolio/feeds/test-room.battery-level"
+	#define MQTT_PUB_TOPIC5		"sircoolio/feeds/test-room.battery-voltage"
+	#define MQTT_PUB_TOPIC6		"sircoolio/feeds/test-room.rssi"
 
 	// #define MQTT_PUB_TOPIC1		"sircoolio/feeds/test-headless.temperature"
 	// #define MQTT_PUB_TOPIC2		"sircoolio/feeds/test-headless.humidity"
@@ -99,8 +106,9 @@ const int timeZone = -7;  // USA PDT
 	// Standard set of tag values used for each sensor data point stored to InfluxDB.  Reuses
   // CLIENT_ID as defined anove here in config.h as well as device location (e.g., room in 
   // the house) and site (indoors vs. outdoors, typically).
-	//#define DEVICE_LOCATION "test room"
-	#define DEVICE_LOCATION "lab-office"
+	#define DEVICE_LOCATION "test room"
+	//#define DEVICE_LOCATION "kitchen"
+	//#define DEVICE_LOCATION "cellar"
 	#define DEVICE_SITE "indoor"
 	#define DEVICE_TYPE "air quality"
 #endif

--- a/config.h
+++ b/config.h
@@ -111,6 +111,8 @@ const int timeZone = -7;  // USA PDT
 	//#define DEVICE_LOCATION "cellar"
 	#define DEVICE_SITE "indoor"
 	#define DEVICE_TYPE "air quality"
+
+	#define INFLUX_ATTEMPT_LIMIT 	5 	// max connection attempts to Influxdb
 #endif
 
 // Post data to the internet via dweet.io.  Set DWEET_DEVICE to be a

--- a/config.h
+++ b/config.h
@@ -1,9 +1,9 @@
 // conditional compile flags
-#define DEBUG 	// Output to serial port
+//#define DEBUG 	// Output to serial port
 //#define RJ45  	// use Ethernet
 #define WIFI    	// use WiFi
 #define MQTTLOG 	// log sensor data to MQTT broker
-#define DWEET     // Post sensor readings to dweet.io
+//#define DWEET     // Post sensor readings to dweet.io
 #define INFLUX  	// Log data to remote InfluxDB server
 #define	SCREEN		// use screen as output
 
@@ -43,16 +43,16 @@ const int timeZone = -7;  // USA PDT
 // based on a settings curve in the LC709203F datasheet
 // #define BATTERY_APA 0x08 // 100mAH
 // #define BATTERY_APA 0x0B // 200mAH
-//#define BATTERY_APA 0x10 // 500mAH
+#define BATTERY_APA 0x10 // 500mAH
 // #define BATTERY_APA 0x19 // 1000mAH
 // #define BATTERY_APA 0x1D // 1200mAH
-#define BATTERY_APA 0x2D // 2000mAH
+//#define BATTERY_APA 0x2D // 2000mAH
 //#define BATTERY_APA 0x32 // 2500mAH
 // #define BATTERY_APA 0x36 // 3000mAH
 
 // set client ID; used by mqtt and wifi
-#define CLIENT_ID "AQ-test-room"
-//#define CLIENT_ID "AQ-lab-office"
+//#define CLIENT_ID "AQ-test-room"
+#define CLIENT_ID "AQ-lab-office"
 //#define CLIENT_ID "AQ-kitchen"
 //#define CLIENT_ID "AQ-cellar"
 
@@ -70,10 +70,12 @@ const int timeZone = -7;  // USA PDT
 	// #define MQTT_PUB_TOPIC3		"sircoolio/feeds/master-bedroom.co2"
 	// #define MQTT_PUB_TOPIC4		"sircoolio/feeds/master-bedroom.battery-level"
 
-	// #define MQTT_PUB_TOPIC1		"sircoolio/feeds/lab-office.temperature"
-	// #define MQTT_PUB_TOPIC2		"sircoolio/feeds/lab-office.humidity"
-	// #define MQTT_PUB_TOPIC3		"sircoolio/feeds/lab-office.co2"
-	// #define MQTT_PUB_TOPIC4		"sircoolio/feeds/lab-office.battery-level"
+	#define MQTT_PUB_TOPIC1		"sircoolio/feeds/lab-office.temperature"
+	#define MQTT_PUB_TOPIC2		"sircoolio/feeds/lab-office.humidity"
+	#define MQTT_PUB_TOPIC3		"sircoolio/feeds/lab-office.co2"
+	#define MQTT_PUB_TOPIC4		"sircoolio/feeds/lab-office.battery-level"
+	#define MQTT_PUB_TOPIC5		"sircoolio/feeds/lab-office.battery-voltage"
+	#define MQTT_PUB_TOPIC6		"sircoolio/feeds/lab-office.rssi"
 
 	// #define MQTT_PUB_TOPIC1		"sircoolio/feeds/kitchen.temperature"
 	// #define MQTT_PUB_TOPIC2		"sircoolio/feeds/kitchen.humidity"
@@ -85,12 +87,12 @@ const int timeZone = -7;  // USA PDT
 	// #define MQTT_PUB_TOPIC3		"sircoolio/feeds/cellar.co2"
 	// #define MQTT_PUB_TOPIC4		"sircoolio/feeds/cellar.battery-level"
 
-	#define MQTT_PUB_TOPIC1		"sircoolio/feeds/test-room.temperature"
-	#define MQTT_PUB_TOPIC2		"sircoolio/feeds/test-room.humidity"
-	#define MQTT_PUB_TOPIC3		"sircoolio/feeds/test-room.co2"
-	#define MQTT_PUB_TOPIC4		"sircoolio/feeds/test-room.battery-level"
-	#define MQTT_PUB_TOPIC5		"sircoolio/feeds/test-room.battery-voltage"
-	#define MQTT_PUB_TOPIC6		"sircoolio/feeds/test-room.rssi"
+	// #define MQTT_PUB_TOPIC1		"sircoolio/feeds/test-room.temperature"
+	// #define MQTT_PUB_TOPIC2		"sircoolio/feeds/test-room.humidity"
+	// #define MQTT_PUB_TOPIC3		"sircoolio/feeds/test-room.co2"
+	// #define MQTT_PUB_TOPIC4		"sircoolio/feeds/test-room.battery-level"
+	// #define MQTT_PUB_TOPIC5		"sircoolio/feeds/test-room.battery-voltage"
+	// #define MQTT_PUB_TOPIC6		"sircoolio/feeds/test-room.rssi"
 
 	// #define MQTT_PUB_TOPIC1		"sircoolio/feeds/test-headless.temperature"
 	// #define MQTT_PUB_TOPIC2		"sircoolio/feeds/test-headless.humidity"
@@ -106,9 +108,10 @@ const int timeZone = -7;  // USA PDT
 	// Standard set of tag values used for each sensor data point stored to InfluxDB.  Reuses
   // CLIENT_ID as defined anove here in config.h as well as device location (e.g., room in 
   // the house) and site (indoors vs. outdoors, typically).
-	#define DEVICE_LOCATION "test room"
+	//#define DEVICE_LOCATION "test room"
 	//#define DEVICE_LOCATION "kitchen"
 	//#define DEVICE_LOCATION "cellar"
+	#define DEVICE_LOCATION "lab-office"
 	#define DEVICE_SITE "indoor"
 	#define DEVICE_TYPE "air quality"
 

--- a/post_dweet.cpp
+++ b/post_dweet.cpp
@@ -20,7 +20,7 @@ extern bool internetAvailable;
 
 // Post a dweet to report the various sensor reading.  This routine blocks while
 // talking to the network, so may take a while to execute.
-void post_dweet(uint16_t co2, float tempF, float humidity, float battpct, float battv)
+void post_dweet(uint16_t co2, float tempF, float humidity, float battpct, float battv, int rssi)
 {
 
   /*
@@ -42,10 +42,10 @@ void post_dweet(uint16_t co2, float tempF, float humidity, float battpct, float 
   */
 
   // Use HTTP post and send a data payload as JSON
-  String device_info = "{\"rssi\":\""   + String(WiFi.RSSI())        + "\"," +
+  String device_info = "{\"rssi\":\""   + String(rssi)        + "\"," +
                        "\"ipaddr\":\"" + WiFi.localIP().toString()  + "\",";
   String battery_info;
-  if(batteryAvailable) {
+  if((battpct !=10000)&&(battv != 10000)) {
     battery_info = "\"battery_percent\":\"" + String(battpct) + "\"," +
                    "\"battery_voltage\":\"" + String(battv)   + "\",";
   }

--- a/post_mqtt.cpp
+++ b/post_mqtt.cpp
@@ -65,35 +65,61 @@ extern bool internetAvailable;
     }
   }
 
-  int mqttBatteryUpdate(float cellPercent)
+  int mqttDeviceInfoUpdate(float cellPercent, float cellVoltage, int rssi)
   {
-    // Adafruit_MQTT_Publish batteryLevelPub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC4, MQTT_QOS_1);
-    Adafruit_MQTT_Publish batteryLevelPub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC4);
+    Adafruit_MQTT_Publish batteryPercentPub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC4, MQTT_QOS_1); // if problematic, remove QOS parameter
+    Adafruit_MQTT_Publish batteryVoltagePub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC5, MQTT_QOS_1);
+    Adafruit_MQTT_Publish rssiLevelPub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC6, MQTT_QOS_1);
+    int result = 1;
 
-    if (batteryAvailable)
-    {    
-      mqttConnect();
-      if (batteryLevelPub.publish(cellPercent))
+    mqttConnect();
+
+    if (cellPercent != 10000)
+    {
+      if (batteryPercentPub.publish(cellPercent))
       {
-        debugMessage(String("MQTT battery percent publish with value:") + cellPercent);
-        return 1;
+        debugMessage("MQTT publish: Battery Percent succeeded");
       }
       else
       {
-        debugMessage(String("MQTT battery percent publish failed at:") + aq_network.dateTimeString());
-        return 0;
+        debugMessage("MQTT publish: Battery Percent failed");
+        result = 0;
       }
-      aq_mqtt.disconnect();
     }
-    return 0;
+
+    if (cellVoltage != 10000)
+    {
+      if (batteryVoltagePub.publish(cellVoltage))
+      {
+        debugMessage("MQTT publish: Battery Voltage succeeded");
+      }
+      else
+      {
+        debugMessage("MQTT publish: Battery Percent failed");
+        result = 0;
+      }
+    }
+
+    if (rssiLevelPub.publish(rssi))
+    {
+      debugMessage("MQTT publish: WiFi RSSI succeeded");
+    }
+    else
+    {
+      debugMessage("MQTT publish: WiFi RSSI failed");
+      result = 0;
+    }
+
+    aq_mqtt.disconnect();
+    return(result);
   }
   
   int mqttSensorUpdate(uint16_t co2, float tempF, float humidity)
   // Publishes sensor data to MQTT broker
   {
-    Adafruit_MQTT_Publish tempPub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC1);
-    Adafruit_MQTT_Publish humidityPub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC2);
-    Adafruit_MQTT_Publish co2Pub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC3);
+    Adafruit_MQTT_Publish tempPub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC1, MQTT_QOS_1);
+    Adafruit_MQTT_Publish humidityPub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC2, MQTT_QOS_1);
+    Adafruit_MQTT_Publish co2Pub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TOPIC3, MQTT_QOS_1);
     int result = 1;
     
     mqttConnect();


### PR DESCRIPTION
Adding battery voltage and RSSI values to data stores. MQTT required new code and changed API call. DWEET was already storing RSSI, just changed to the aq_network call to get the value. InfluxDB was already stubbed to support RSSI value.